### PR TITLE
Add scrolling behaviour to overflowing `pre`

### DIFF
--- a/pycco_resources/__init__.py
+++ b/pycco_resources/__init__.py
@@ -86,6 +86,7 @@ div.docs {
   .docs pre {
     margin: 15px 0 15px;
     padding-left: 15px;
+    overflow-y: scroll;
   }
   .docs p tt, .docs p code {
     background: #f8f8ff;


### PR DESCRIPTION
When a `pre` tag contains lengthy single line content, it masks the actual code in the generated HTML documentation. This simple fix make the horizontal content scrollable instead of overflowing into the code area.